### PR TITLE
Change the contract for column.cell so that it is just a general purpose...

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ It might be fun if it was possible to delete table entries directly. We can defi
 
 ```javascript
 {
-    cell: (property, value, rowIndex, columnIndex) => {
+    cell: (value, data, rowIndex, property) => {
         var remove = () => {
             // this could go through flux etc.
             this.state.data.splice(rowIndex, 1);

--- a/README.md
+++ b/README.md
@@ -97,31 +97,19 @@ var data = [
 In addition we might want to improve the formatting of these new fields. Here's an expanded column definition (new fields only):
 
 ```javascript
-var cell = require('reactabular').cell;
-
-...
-// bind context at getInitialState
-var createCell = cell.bind(this);
-
-...
-
 var columns: [
     ...
     {
         property: 'followers',
         header: 'Followers',
         // accuracy per hundred is enough for demoing
-        cell: createCell({
-            formatter: (followers) => followers - (followers % 100)
-        }),
+        formatter: (followers) => followers - (followers % 100),
     },
     {
         property: 'worksWithReactabular',
         header: '1st Class Reactabular',
         // render utf ok if works
-        cell: createCell({
-           formatter: (works) => works && <span>&#10003;</span>
-        }),
+        formatter: (works) => works && <span>&#10003;</span>,
     }
 ];
 ```
@@ -328,21 +316,21 @@ Adding a custom footer for our table is simple. Just write the definition inside
 As you noticed in the custom column section above, Reactabular provides access to table cell rendering. You could implement various cell customizations on top of this. To make it easier to implement custom editors, Reactabular comes with a little shortcut. Here's an example:
 
 ```javascript
-var cell = require('reactabular').cell;
+var cells = require('reactabular').cells;
 var editors = require('reactabular').editors;
 
 ...
 // bind context at getInitialState
-var createCell = cell.bind(this);
+var createEditCell = cells.edit.bind(this);
 
 ...
 
 {
     property: 'estimatedValue',
     header: 'Estimated value',
-    cell: createCell({
+    formatter: (estimatedValue) => parseFloat(estimatedValue).toFixed(2)
+    cell: createEditCell({
         editor: editors.input(),
-        formatter: (estimatedValue) => parseFloat(estimatedValue).toFixed(2)
     }),
 },
 ```

--- a/__tests__/cells/identity-test.js
+++ b/__tests__/cells/identity-test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+jest.dontMock('../../lib/cells/identity.js');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var identity = require('../../lib/cells/identity.js');
+
+describe('identity', function(){
+    it('formats correctly', function() {
+        var value = "never odd or even";
+        expect(identity(value)).toEqual({value: value});
+    });
+});

--- a/__tests__/formatters/identity-test.js
+++ b/__tests__/formatters/identity-test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+jest.dontMock('../../lib/formatters/identity.js');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var identity = require('../../lib/formatters/identity.js');
+
+describe('identity', function(){
+    it('formats correctly', function() {
+        var value = "evil olive";
+        expect(identity(value)).toEqual(value);
+    });
+});

--- a/__tests__/search-test.js
+++ b/__tests__/search-test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 jest.dontMock('../lib/search.jsx');
+jest.dontMock('../lib/formatters/index.js');
+jest.dontMock('../lib/formatters/identity.js');
 
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
@@ -25,7 +27,7 @@ describe('Search', function() {
         var columns = [
             {
                 property: 'first',
-                header: 'First'
+                header: 'First',
             },
             {
                 property: 'second'
@@ -52,7 +54,7 @@ describe('Search', function() {
         var columns = [
             {
                 property: 'first',
-                header: 'First'
+                header: 'First',
             },
         ];
         var value = 'demo';

--- a/__tests__/table-test.js
+++ b/__tests__/table-test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 jest.dontMock('../lib/table.jsx');
+jest.dontMock('../lib/cells/index.js');
+jest.dontMock('../lib/cells/identity.js');
 
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;

--- a/demos/editors_table.jsx
+++ b/demos/editors_table.jsx
@@ -3,7 +3,6 @@
 var React = require('react');
 
 var Table = require('../lib/table.jsx');
-var cell = require('../lib/cell');
 var editors = require('../lib/editors');
 
 var countries = require('./countries');
@@ -11,7 +10,6 @@ var countries = require('./countries');
 
 module.exports = React.createClass({
     getInitialState() {
-        var createCell = cell.bind(this);
 
         return {
             data: [
@@ -39,13 +37,10 @@ module.exports = React.createClass({
                 {
                     property: 'editor',
                     header: 'Editor',
-                    cell: createCell({
-                        formatter: (value) =>
-                            React.createElement(value, {
-                                value: '',
-                                onValue: (value) =>
-                                    console.log(value)
-                            })
+                    formatter: (value) => React.createElement(value, {
+                        value: '',
+                        onValue: (value) =>
+                            console.log(value)
                     }),
                 },
                 {

--- a/demos/full_table.jsx
+++ b/demos/full_table.jsx
@@ -14,7 +14,7 @@ var Table = require('../lib/table.jsx');
 var Search = require('../lib/search.jsx');
 var editors = require('../lib/editors');
 var sortColumn = require('../lib/sort_column');
-var cell = require('../lib/cell');
+var cells = require('../lib/cells');
 
 var countries = require('./countries');
 var generateData = require('./generate_data');
@@ -46,7 +46,7 @@ module.exports = React.createClass({
             fieldGenerators: getFieldGenerators(countryValues),
             properties: properties,
         });
-        var createCell = cell.bind(this);
+        var createEditCell = cells.edit.bind(this);
 
         return {
             data: data,
@@ -70,7 +70,7 @@ module.exports = React.createClass({
                 {
                     property: 'name',
                     header: 'Name',
-                    cell: createCell({
+                    cell: createEditCell({
                         editor: editors.input(),
                     }),
                 },
@@ -81,29 +81,29 @@ module.exports = React.createClass({
                 {
                     property: 'country',
                     header: 'Country',
-                    cell: createCell({
+                    formatter: (country) => find(countries, 'value', country).name,
+                    cell: createEditCell({
                         editor: editors.dropdown(countries),
-                        formatter: (country) => find(countries, 'value', country).name,
                     }),
                 },
                 {
                     property: 'salary',
                     header: 'Salary',
-                    cell: createCell({
+                    formatter: (salary) => parseFloat(salary).toFixed(2),
+                    cell: createEditCell({
                         editor: editors.input(),
-                        formatter: (salary) => parseFloat(salary).toFixed(2)
                     }),
                 },
                 {
                     property: 'active',
                     header: 'Active',
-                    cell: createCell({
+                    formatter: (active) => active && <span>&#10003;</span>,
+                    cell: createEditCell({
                         editor: editors.boolean(),
-                        formatter: (active) => active && <span>&#10003;</span>,
                     }),
                 },
                 {
-                    cell: (value, data, rowIndex, property) => {
+                    cell: function(value, data, rowIndex, property) {
                         var edit = () => {
                             var schema = {
                                 type: 'object',
@@ -159,7 +159,7 @@ module.exports = React.createClass({
                                 </span>
                             </span>
                         };
-                    },
+                    }.bind(this),
                 },
             ],
             modal: {

--- a/demos/full_table.jsx
+++ b/demos/full_table.jsx
@@ -103,7 +103,7 @@ module.exports = React.createClass({
                     }),
                 },
                 {
-                    cell: (property, value, rowIndex, columnIndex) => {
+                    cell: (value, data, rowIndex, property) => {
                         var edit = () => {
                             var schema = {
                                 type: 'object',

--- a/lib/cell.js
+++ b/lib/cell.js
@@ -8,10 +8,11 @@ module.exports = function(o) {
     var formatter = o.formatter || id;
     var editor = o.editor;
 
-    return (property, value, rowIndex, columnIndex) => {
-        var idx = rowIndex.toString() + '-' + columnIndex.toString();
+    return (value, data, rowIndex, property) => {
+        var idx = rowIndex.toString() + '-' + property;
         var editedCells = context.state.editedCells || [];
         var i = editedCells.indexOf(idx);
+        var formattedValue = formatter(value);
 
         if(i >= 0) {
             var editorElement = React.createElement(editor, {
@@ -32,10 +33,10 @@ module.exports = function(o) {
             });
 
             return {
+                searchValue: formattedValue,
                 value: editorElement
             };
         }
-        var formattedValue = formatter(value, rowIndex);
 
         if(editor) {
             return {
@@ -48,11 +49,13 @@ module.exports = function(o) {
                         editedCells: editedCells
                     });
                 },
+                searchValue: formattedValue,
                 value: formattedValue
             };
         }
 
         return {
+            searchValue: formattedValue,
             value: formattedValue
         };
     };

--- a/lib/cells/edit.jsx
+++ b/lib/cells/edit.jsx
@@ -5,14 +5,12 @@ var React = require('react');
 
 module.exports = function(o) {
     var context = this;
-    var formatter = o.formatter || id;
     var editor = o.editor;
 
     return (value, data, rowIndex, property) => {
         var idx = rowIndex.toString() + '-' + property;
         var editedCells = context.state.editedCells || [];
         var i = editedCells.indexOf(idx);
-        var formattedValue = formatter(value);
 
         if(i >= 0) {
             var editorElement = React.createElement(editor, {
@@ -33,7 +31,6 @@ module.exports = function(o) {
             });
 
             return {
-                searchValue: formattedValue,
                 value: editorElement
             };
         }
@@ -49,16 +46,12 @@ module.exports = function(o) {
                         editedCells: editedCells
                     });
                 },
-                searchValue: formattedValue,
-                value: formattedValue
+                value: value
             };
         }
 
         return {
-            searchValue: formattedValue,
-            value: formattedValue
+            value: value
         };
     };
 };
-
-function id(a) {return a;}

--- a/lib/cells/identity.js
+++ b/lib/cells/identity.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var React = require('react');
+
+
+module.exports = (value, data, rowIndex, property) => {return {value: value};};

--- a/lib/cells/index.js
+++ b/lib/cells/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+    identity: require('./identity.js'),
+    edit: require('./edit.jsx'),
+};

--- a/lib/formatters/identity.js
+++ b/lib/formatters/identity.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var React = require('react');
+
+
+module.exports = (value) => {return value;};

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+module.exports = {
+    identity: require('./identity.js'),
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,5 +6,6 @@ module.exports = {
     Search: require('./search.jsx'),
     sortColumn: require('./sort_column.js'),
     editors: require('./editors'),
-    cell: require('./cell'),
+    formatters: require('./formatters'),
+    cells: require('./cells'),
 };

--- a/lib/search.jsx
+++ b/lib/search.jsx
@@ -55,10 +55,11 @@ module.exports = React.createClass({
         });
 
         function isColumnVisible(row, column) {
-            var formatter = column.formatter || id;
-            var formattedValue = formatter(row[column.property]);
-
-            if(!formattedValue) {
+            var cell = column.cell || defaultCell;
+            var value = row[column.property];
+            var props = cell(value, data, 0, column.property);
+            var formattedValue = props.searchValue || props.value;
+            if (!formattedValue) {
                 return;
             }
 
@@ -70,4 +71,5 @@ module.exports = React.createClass({
 });
 
 function id(a) {return a;}
+function defaultCell(a) {return {value: a};}
 function noop() {}

--- a/lib/search.jsx
+++ b/lib/search.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var formatters = require('./formatters');
 
 
 module.exports = React.createClass({
@@ -55,10 +56,9 @@ module.exports = React.createClass({
         });
 
         function isColumnVisible(row, column) {
-            var cell = column.cell || defaultCell;
             var value = row[column.property];
-            var props = cell(value, data, 0, column.property);
-            var formattedValue = props.searchValue || props.value;
+            var formatter = column.formatter || formatters.identity; 
+            var formattedValue = formatter(value);
             if (!formattedValue) {
                 return;
             }
@@ -71,5 +71,4 @@ module.exports = React.createClass({
 });
 
 function id(a) {return a;}
-function defaultCell(a) {return {value: a};}
 function noop() {}

--- a/lib/table.jsx
+++ b/lib/table.jsx
@@ -48,23 +48,18 @@ module.exports = React.createClass({
                     {data.map((row, i) => <tr key={i + '-row'}>{
                         columns.map((column, j) => {
                             var value = row[column.property];
-                            var cell = column.cell;
+                            var cell = column.cell || defaultCell;
+                            var props = cell(value, data, i, column.property);
+                            var content = props.value;
 
-                            if(cell) {
-                                var props = cell(column.property, value, i, j);
-                                var content = props.value;
+                            props = update(props, {
+                                $merge: {
+                                    searchValue: undefined,
+                                    value: undefined,
+                                },
+                            });
 
-                                props = update(props, {
-                                    $merge: {
-                                        value: undefined,
-                                    },
-                                });
-
-                                return <td key={j + '-cell'} {...props}>{content}</td>
-                            }
-                            else {
-                                return <td key={j + '-cell'}>{value}</td>
-                            }
+                            return <td key={j + '-cell'} {...props}>{content}</td>
                         }
                     )}</tr>)}
                 </tbody>
@@ -73,3 +68,5 @@ module.exports = React.createClass({
         );
     },
 });
+
+function defaultCell(a) {return {value: a};}

--- a/lib/table.jsx
+++ b/lib/table.jsx
@@ -1,7 +1,9 @@
 'use strict';
 
 var React = require('react/addons');
+var cells = require('./cells');
 var cx = React.addons.classSet;
+var formatters = require('./formatters');
 var update = React.addons.update;
 var zip = require('annozip');
 
@@ -48,13 +50,15 @@ module.exports = React.createClass({
                     {data.map((row, i) => <tr key={i + '-row'}>{
                         columns.map((column, j) => {
                             var value = row[column.property];
-                            var cell = column.cell || defaultCell;
-                            var props = cell(value, data, i, column.property);
+                            var formatter = column.formatter || formatters.identity;
+                            var formattedValue = formatter(value);
+
+                            var cell = column.cell || cells.identity;
+                            var props = cell(formattedValue, data, i, column.property);
                             var content = props.value;
 
                             props = update(props, {
                                 $merge: {
-                                    searchValue: undefined,
                                     value: undefined,
                                 },
                             });
@@ -68,5 +72,3 @@ module.exports = React.createClass({
         );
     },
 });
-
-function defaultCell(a) {return {value: a};}


### PR DESCRIPTION
... formatter

Closes #10.

Here are some of the changes that have been made:
- `column.cell` method signature has changed. This is now `(value, data, rowIndex, property)`. The `columnIndex` didn't seem particularly useful since columns weren't passed.
- `column.cell` now acts as the method which applies both formatting and behaviors.
- `column.cell` is now expected to return a JSON object. Any additional fields will be passed in as properties to the `<td>`.
```
{
    searchValue: {searchable value}
    value: {value to render}
    ...
}
```
- The search now uses the `column.cell` method. If `searchValue` is not provided, search is performed on `value`.
- `lib/cell.js` really exists now as a backwards compatibility bridge
- Just a formatter would be:
```
{
    ...
    cell: function(value) {return {value: value}}
    ...
}
```
- Line 60 of `lib/search.jsx` is kind of iffy since a `rowIndex` of 0 is passed as a placeholder. This can probably be fixed by splitting out code that applies formatting and the code that applies behaviors.