### PR TITLE
Extend search to allow for predicates

### DIFF
--- a/__tests__/predicates/infix-test.js
+++ b/__tests__/predicates/infix-test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+jest.dontMock('../../lib/predicates/infix.js');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var infix = require('../../lib/predicates/infix.js');
+
+describe('infix', function() {
+    it('matches correctly', function() {
+        var queryTerm = "light";
+        var text = "enlighten";
+
+        var predicate = infix(queryTerm);
+
+        expect(predicate.matches(text)).toEqual(true);
+    });
+
+    it('does not match', function() {
+        var queryTerm = "light";
+        var text = "dark";
+
+        var predicate = infix(queryTerm);
+
+        expect(predicate.matches(text)).toEqual(false);
+    });
+});

--- a/__tests__/predicates/prefix-test.js
+++ b/__tests__/predicates/prefix-test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+jest.dontMock('../../lib/predicates/prefix.js');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+
+var prefix = require('../../lib/predicates/prefix.js');
+
+describe('prefix', function() {
+    it('matches correctly', function() {
+        var queryTerm = "lay";
+        var text = "layout";
+
+        var predicate = prefix(queryTerm);
+
+        expect(predicate.matches(text)).toEqual(true);
+    });
+
+    it('does not match', function() {
+        var queryTerm = "lay";
+        var text = "outlay";
+
+        var predicate = prefix(queryTerm);
+
+        expect(predicate.matches(text)).toEqual(false);
+    });
+});

--- a/__tests__/search-test.js
+++ b/__tests__/search-test.js
@@ -3,6 +3,8 @@
 jest.dontMock('../lib/search.jsx');
 jest.dontMock('../lib/formatters/index.js');
 jest.dontMock('../lib/formatters/identity.js');
+jest.dontMock('../lib/predicates/index.js');
+jest.dontMock('../lib/predicates/prefix.js');
 
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,5 +7,6 @@ module.exports = {
     sortColumn: require('./sort_column.js'),
     editors: require('./editors'),
     formatters: require('./formatters'),
+    predicates: require('./predicates'),
     cells: require('./cells'),
 };

--- a/lib/predicates/index.js
+++ b/lib/predicates/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+
+module.exports = {
+    infix: require('./infix.js'),
+    prefix: require('./prefix.js')
+};

--- a/lib/predicates/infix.js
+++ b/lib/predicates/infix.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (infix) {
+    return {
+        matches: function(searchText) {
+            return searchText.indexOf(infix) != -1;
+        }
+    }
+}

--- a/lib/predicates/prefix.js
+++ b/lib/predicates/prefix.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (prefix) {
+    return {
+        matches: function(searchText) {
+            return searchText.indexOf(prefix) === 0;
+        }
+    }
+}

--- a/lib/search.jsx
+++ b/lib/search.jsx
@@ -2,9 +2,15 @@
 
 var React = require('react/addons');
 var formatters = require('./formatters');
-
+var predicates = require('./predicates');
 
 module.exports = React.createClass({
+    getDefaultProps() {
+        return {
+            strategy: predicates.prefix
+        };
+    },
+
     render() {
         var columns = this.props.columns || [];
         var options = [{
@@ -51,7 +57,7 @@ module.exports = React.createClass({
 
         (this.props.onResult || noop)({
             searchData: data.filter((row) =>
-                columns.filter(isColumnVisible.bind(null, row)).length > 0
+                columns.filter(isColumnVisible.bind(this, row)).length > 0
             )
         });
 
@@ -64,7 +70,8 @@ module.exports = React.createClass({
             }
 
             if(formattedValue.toLowerCase) {
-                return formattedValue.toLowerCase().indexOf(query.toLowerCase()) === 0;
+                var predicate = this.props.strategy(query.toLowerCase());
+                return predicate.matches(formattedValue.toLowerCase());
             }
         }
     },


### PR DESCRIPTION
Search is just a special case of filtering. I kept the default search to be prefix. I'm planning on adding some search highlighting and then switching it to infix in a subsequent PR.