### PR TITLE
Add a transform field for search on column definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ The interesting bit here is `this.setState.bind(this)`. When you enter something
 
 In order to take these changes in count, you will need to update the table state. Hence it is preferable to set up table `data` and `columns` at `getInitialState`. Alternatively you could hook into some implementation of Flux here.
 
+The Search component takes in the same structure for columns as the Table. By default, search will be performed across the raw data. However, a one argument function can be provided in the `search` field of a column to transform the data before searching on it.
+
+```javascript
+    {
+        property: 'salary',
+        header: 'Salary',
+        search: (salary) => parseFloat(salary).toFixed(2)
+    }
+```
+
 ## Paginating a Table
 
 The next natural step could be implementing a pagination for our table. We could add two separately controls for that. One to display amount of items per page and one to control the current page. This will take some additional wiring.

--- a/demos/full_table.jsx
+++ b/demos/full_table.jsx
@@ -83,6 +83,7 @@ module.exports = React.createClass({
                     property: 'country',
                     header: 'Country',
                     formatter: (country) => find(countries, 'value', country).name,
+                    search: (country) => find(countries, 'value', country).name,
                     cell: createEditCell({
                         editor: editors.dropdown(countries),
                     }),
@@ -91,6 +92,7 @@ module.exports = React.createClass({
                     property: 'salary',
                     header: 'Salary',
                     formatter: (salary) => parseFloat(salary).toFixed(2),
+                    search: (salary) => parseFloat(salary).toFixed(2),
                     cell: createEditCell({
                         editor: editors.input(),
                     }),

--- a/lib/search.jsx
+++ b/lib/search.jsx
@@ -63,7 +63,7 @@ module.exports = React.createClass({
 
         function isColumnVisible(row, column) {
             var value = row[column.property];
-            var formatter = column.formatter || formatters.identity; 
+            var formatter = column.search || formatters.identity;
             var formattedValue = formatter(value);
             if (!formattedValue) {
                 return;


### PR DESCRIPTION
The point here is to decouple the search component from the table component. `formatter` may not have always been the correct thing to use, especially if the developer decided to stick in extra markup.

I'm envisioning that the current `formatter` is going to get collapsed into `cell` (or some better named field). This will consist of a pipeline of transforms represented by an ordered list of functions.