### PR TITLE
Move filtering into the Search component

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ getInitialState() {
         ...
         // Search `onChange` will emit a structure like this
         search: {
-            query: '',
             column: '',
+            data: [],
+            query: ''
         },
         ...
     };
@@ -127,19 +128,13 @@ getInitialState() {
 Then at your `render` you could do:
 
 ```jsx
-var searchData = Search.search(
-    this.state.search,
-    this.state.columns,
-    this.state.data
-);
-
 <div className='search-container'>
     Search <Search columns={columns} onChange={this.setState.bind(this)}></Search>
 </div>
-<Table data={searchData} />
+<Table data={this.state.search.data} />
 ```
 
-`onChange` will update `search` data. It will then be used to filter the data using `Search.search`. You can replace `onChange` handler with something more custom and skip filtering like this altogether if you are dealing with a backend.
+`onChange` will update `search` data. You can replace `onChange` handler with something more custom and skip filtering like this altogether if you are dealing with a backend.
 
 ## Highlighting Search Results
 
@@ -161,12 +156,16 @@ var columns: [
 ];
 ```
 
-We just pipe the formatted cell to `highlight` helper which then figures out what part of the search result hit it, if it hit altogether. If there's a match, it will emit
+We just pipe the formatted cell to `highlight` helper which then figures out what part of the search result hit it, if it hit altogether. If there's a match, it will emit a `span` with `class='highlight'`. For example, if the search term was 'oo' and
+the data under evaluation 'noon moon', the following structure would be emitted:
 
 ```jsx
 <span className='search-result'>
-    <span className='highlight'>{match}</span>
-    <span className='rest'>{rest}</span>
+    <span>n</span>
+    <span className='highlight'>oo</span>
+    <span>n m</span>
+    <span className='highlight'>oo</span>
+    <span>n</span>
 </span>
 ```
 

--- a/__tests__/search-test.js
+++ b/__tests__/search-test.js
@@ -2,9 +2,9 @@
 
 jest.dontMock('../lib/search.jsx');
 jest.dontMock('../lib/formatters/index.js');
-jest.dontMock('../lib/formatters/identity.js');
+jest.dontMock('../lib/formatters/lowercase.js');
 jest.dontMock('../lib/predicates/index.js');
-jest.dontMock('../lib/predicates/prefix.js');
+jest.dontMock('../lib/predicates/infix.js');
 
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
@@ -66,7 +66,7 @@ describe('Search', function() {
             },
         ];
         var result = function(d) {
-            expect(d.search.data).toEqual(data);
+            expect(d.data).toEqual(data);
         };
         var search = TestUtils.renderIntoDocument(
             <Search columns={columns} data={data} onResult={result} />
@@ -92,7 +92,7 @@ describe('Search', function() {
             },
         ];
         var result = function(d) {
-            expect(d.search.data.length).toEqual(0);
+            expect(d.data.length).toEqual(0);
         };
         var search = TestUtils.renderIntoDocument(
             <Search columns={columns} data={data} onResult={result} />

--- a/demos/full_table.jsx
+++ b/demos/full_table.jsx
@@ -72,8 +72,9 @@ module.exports = React.createClass({
             data: data,
             formatters: formatters,
             search: {
-                query: '',
                 column: '',
+                data: [],
+                query: ''
             },
             header: {
                 onClick: (column) => {
@@ -216,23 +217,23 @@ module.exports = React.createClass({
             pagination: {
                 page: 0,
                 perPage: 10
-            },
+            }
         };
+    },
+
+    onSearch(search) {
+        this.setState({
+            search: search
+        });
     },
 
     render() {
         var header = this.state.header;
         var columns = this.state.columns;
-        var data = this.state.data;
-        var searchData = Search.search(
-            this.state.search,
-            this.state.columns,
-            this.state.data
-        );
 
         var pagination = this.state.pagination;
 
-        var paginated = Paginator.paginate(searchData, pagination);
+        var paginated = Paginator.paginate(this.state.search.data, pagination);
 
         return (
             <div>
@@ -241,7 +242,7 @@ module.exports = React.createClass({
                         Per page <input type='text' defaultValue={pagination.perPage} onChange={this.onPerPage}></input>
                     </div>
                     <div className='search-container'>
-                        Search <Search columns={columns} onChange={this.setState.bind(this)} />
+                        Search <Search columns={columns} data={this.state.data} onChange={this.onSearch} />
                     </div>
                 </div>
                 <Table className='pure-table pure-table-striped' header={header} columns={columns} data={paginated.data}>

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -3,4 +3,5 @@
 
 module.exports = {
     identity: require('./identity.js'),
+    lowercase: require('./lowercase.js')
 };

--- a/lib/formatters/lowercase.js
+++ b/lib/formatters/lowercase.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+module.exports = (value) => {
+    return value.toLowerCase();
+};


### PR DESCRIPTION
Here are a list of changes that happened:
- changed highlighting logic so that it'll highlight any instance
  - There's some annoyance here since the highlighter is currently coupled to logic inside the search
- switched default search option to lowercase and infix
- changed it so that Search component also does the filtering. This results in `onSearch` returning `data`.

We may want to consider bumping the major version number since this change is definitely not backwards compatible.