### PR TITLE
Problem when erasing the whole content of the input

### DIFF
--- a/src/editors/input.jsx
+++ b/src/editors/input.jsx
@@ -14,14 +14,14 @@ module.exports = () => {
 
         getInitialState() {
             return {
-                value: '',
+                value: this.props.value,
             };
         },
 
         render() {
             return (
                 <input
-                    value={this.state.value || this.props.value}
+                    value={this.state.value }
                     onChange={this.onChange}
                     onKeyUp={this.keyUp}
                     onBlur={this.done}>


### PR DESCRIPTION
While editing an input field (cell), if you erase all chars from it, it will reinitialize the value of the input field to one defined through the component props. The PR fixes the problem by using only the state when rendering and setting the state to the props value at first.