### PR TITLE
Attempt to simplify the cell rendering API

### DIFF
--- a/__tests__/table-test.js
+++ b/__tests__/table-test.js
@@ -77,6 +77,63 @@ describe('Table', function() {
         expect(trs.length).toEqual(data.length + 1);
     });
 
+    it('should allow manipulation of complex objects in cell functions', function() {
+        var columns = [
+            {
+                property: 'basic',
+                header: 'Basic',
+            },
+            {
+                property: 'identity',
+                header: 'Identity',
+                cell: (v) => v,
+            },
+            {
+                property: 'math',
+                header: 'Simple Math',
+                cell: (v) => v - 23,
+            },
+            {
+                property: 'complex',
+                header: 'Cell Props',
+                cell: (v) => ({ value:v, props:{className:'complex'}}),
+            },
+            {
+                property: 'jsx',
+                header: 'JSX',
+                cell: (v) => (<a href={'http://' + v.id}>{v.name}</a>),
+            },
+        ];
+        var data = [
+            {
+              basic: 'basic',
+              identity: 'ident',
+              math: 123, 
+              complex: 'somestr',
+              jsx: {id:"some_id_123", name:"helloworld"}
+            },
+        ];
+        var table = TestUtils.renderIntoDocument(
+            <Table columns={columns} data={data} />
+        );
+        
+        var tds = TestUtils.scryRenderedDOMComponentsWithTag(table, 'td');
+        expect(tds.length).toEqual(columns.length);
+        expect(tds[0].getDOMNode().innerHTML).toBe('basic');
+        expect(tds[1].getDOMNode().innerHTML).toBe('ident');
+        expect(tds[2].getDOMNode().innerHTML).toBe('100');
+
+        expect(tds[3].getDOMNode().className).toBe('complex');
+        expect(tds[3].getDOMNode().innerHTML).toBe('somestr');
+
+        var link = TestUtils.findRenderedDOMComponentWithTag(table, 'a');
+        var linkDom = link.getDOMNode();
+        expect(linkDom.parentNode).toEqual(tds[4].getDOMNode());
+        expect(linkDom.href).toBe('http://some_id_123/')
+        expect(linkDom.innerHTML).toBe('helloworld');
+
+    });
+
     it('should render correctly with no properties', function() {
         var renderedTable = TestUtils.renderIntoDocument(
             <Table/>

--- a/__tests__/table-test.js
+++ b/__tests__/table-test.js
@@ -96,7 +96,7 @@ describe('Table', function() {
             {
                 property: 'complex',
                 header: 'Cell Props',
-                cell: (v) => ({ value:v, props:{className:'complex'}}),
+                cell: (v) => ({value: v, props: {className: 'complex'}}),
             },
             {
                 property: 'jsx',
@@ -108,15 +108,15 @@ describe('Table', function() {
             {
               basic: 'basic',
               identity: 'ident',
-              math: 123, 
+              math: 123,
               complex: 'somestr',
-              jsx: {id:"some_id_123", name:"helloworld"}
+              jsx: { id: 'some_id_123', name: 'helloworld'}
             },
         ];
         var table = TestUtils.renderIntoDocument(
             <Table columns={columns} data={data} />
         );
-        
+
         var tds = TestUtils.scryRenderedDOMComponentsWithTag(table, 'td');
         expect(tds.length).toEqual(columns.length);
         expect(tds[0].getDOMNode().innerHTML).toBe('basic');
@@ -129,7 +129,7 @@ describe('Table', function() {
         var link = TestUtils.findRenderedDOMComponentWithTag(table, 'a');
         var linkDom = link.getDOMNode();
         expect(linkDom.parentNode).toEqual(tds[4].getDOMNode());
-        expect(linkDom.href).toBe('http://some_id_123/')
+        expect(linkDom.href).toBe('http://some_id_123/');
         expect(linkDom.innerHTML).toBe('helloworld');
 
     });

--- a/src/table.js
+++ b/src/table.js
@@ -71,35 +71,18 @@ module.exports = React.createClass({
                         columns.map((column, j) => {
                             var property = column.property;
                             var value = row[property];
-                            var cell = column.cell || [formatters.identity];
-                            var content;
+                            if (isFunction(column.cell)) {
+                              // Always replace value with the result of cell()
+                              value = column.cell(value, data, i, property);
+                            }
 
-                            cell = isFunction(cell) ? [cell] : cell;
+                            var content = {value: value};
 
-                            content = reduce([value].concat(cell), (v, fn) => {
-                                if(v && React.isValidElement(v.value)) {
-                                    return v;
-                                }
-
-                                if(isPlainObject(v)) {
-                                    return merge(v, {
-                                        value: fn(v.value, data, i, property)
-                                    });
-                                }
-
-                                var val = fn(v, data, i, property);
-
-                                if(val && !isUndefined(val.value)) {
-                                    return val;
-                                }
-
-                                // formatter shortcut
-                                return {
-                                    value: val
-                                };
-                            });
-
-                            content = content || {};
+                            if (isPlainObject(value)) {
+                              // If a plain object was returned, we pass along its keys/values
+                              // to the table cell (e.g. props, value, className, etc.)
+                              content = merge(content, value);
+                            }
 
                             return <td key={j + '-cell'} {...content.props}>{content.value}</td>;
                         }

--- a/src/table.js
+++ b/src/table.js
@@ -3,14 +3,11 @@ var _ = require('lodash');
 
 var merge = _.merge;
 var transform = _.transform;
-var reduce = _.reduce;
 var isFunction = _.isFunction;
 var isPlainObject = _.isPlainObject;
-var isUndefined = _.isUndefined;
 
 var React = require('react/addons');
 var cx = require('classnames');
-var formatters = require('./formatters');
 var update = React.addons.update;
 
 


### PR DESCRIPTION
See #60 for context

Simplifies cell-value rendering. The proposed flow:
 * `value` starts as row[property]
 * If a cell function is defined, `value` becomes `cell(value,...)`
 * If value is (still) a plain old object, it is merged into an object containing itself at the `value` key, since it's assumed that all non-`value` keys should be sent as props to the table cell.

I'm definitely not sure I didn't break anything -- especially use-cases that may be implicitly supported but I haven't come across. Tests pass, and I _believe_ the changes to be backwards compatible for all the use-cases I'm aware of.

I've never actually used the react TestUtils before. Neat! My dom-level testing feels a little heavy-handed, so please let me know if there are better ways to do this. 
