### PR TITLE
Possibility to add an extra (optional) header

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -64,6 +64,7 @@ module.exports = React.createClass({
                             );
                         })}
                     </tr>
+                    {header.extraHeader}
                 </thead>
                 <tbody>
                     {data.map((row, i) => <tr key={i + '-row'} {...rowProps(row, i)}>{


### PR DESCRIPTION
Hi!

I have a table with an additional `<tr>` inside the `<thead>` but right now we doesn't have the possibility to add it... So, I wonder if this little change may be acceptable.

What do you think? Maybe there is a better way...