### PR TITLE
Merges props & values of cell functions correctly

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -63,28 +63,20 @@ module.exports = React.createClass({
 
                             cell = isFunction(cell) ? [cell] : cell;
 
-                            content = reduce([value].concat(cell), (v, fn) => {
-                                if(v && React.isValidElement(v.value)) {
+                            content = reduce(cell, (v, fn) => {
+                                if(React.isValidElement(v.value)) {
                                     return v;
                                 }
 
-                                if(!isPlainObject(value) && isPlainObject(v)) {
-                                    return merge(v, {
-                                        value: fn(v.value, data, i, property)
-                                    });
+                                var val = fn(v.value, data, i, property);
+
+                                if(val && isUndefined(val.value)) {
+                                    // formatter shortcut
+                                    val = {value: val};
                                 }
 
-                                var val = fn(v, data, i, property);
-
-                                if(val && !isUndefined(val.value)) {
-                                    return val;
-                                }
-
-                                // formatter shortcut
-                                return {
-                                    value: val
-                                };
-                            });
+                                return merge(v, val);
+                            }, {value: value, props: {}});
 
                             content = content || {};
 

--- a/tests/table_test.js
+++ b/tests/table_test.js
@@ -125,6 +125,33 @@ describe('Table', function() {
         expect(link.innerHTML).to.equal('helloworld');
     });
 
+    it('should aggregate returned props and values by the cell functions', function(){
+        var columns = [
+            {
+                property: 'value',
+                header: '',
+                cell: [
+                    v => ({props: {className: 'fooClass'}, value: v}),
+                    v => ({props: {id: 'fooId'}, value: 'fooContent'+v}),
+                ]
+            }
+        ]
+
+        var data = [
+            {value: 0}
+        ]
+
+        var table = TestUtils.renderIntoDocument(
+            <Table columns={columns} data={data} />
+        )
+
+        var tds = TestUtils.scryRenderedDOMComponentsWithTag(table, 'td');
+        expect(tds).to.have.length(1);
+        expect(tds[0]).to.have.property('className', 'fooClass')
+        expect(tds[0]).to.have.property('id', 'fooId')
+        expect(tds[0]).to.have.property('innerHTML', 'fooContent0')
+    })
+
     it('should render correctly with no properties', function() {
         var renderedTable = TestUtils.renderIntoDocument(
             <Table/>

--- a/tests/table_test.js
+++ b/tests/table_test.js
@@ -128,7 +128,7 @@ describe('Table', function() {
     it('should aggregate returned props and values by the cell functions', function(){
         var columns = [
             {
-                property: 'value',
+                property: 'someData',
                 header: '',
                 cell: [
                     v => ({props: {className: 'fooClass'}, value: v}),
@@ -138,7 +138,7 @@ describe('Table', function() {
         ]
 
         var data = [
-            {value: 0}
+            {someData: 0}
         ]
 
         var table = TestUtils.renderIntoDocument(


### PR DESCRIPTION
Currently the table does not aggregate the following cell functions correctly:

```js
cell: [
  function(v){return {value: v}},
  function(v){return {value: v}}
]
```

By the end of [the reduction loop in table.js](https://github.com/bebraw/reactabular/blob/9d1a67397bd7ae6d0199fe26458ba7564f64360e/src/table.js#L66), the cell content is aggregated as below, which cannot be rendered by React at all. [This test case](https://github.com/bebraw/reactabular/pull/122/files#diff-b9a69566df421fcb64ebcdee2e10dac5) demonstrates a more realistic example.

```js
{value: {value: "the value of the cell"} }
```

This pull request fixes the issue illustrated above.

The logic of reduce callback is simplified by ensuring the reducer callback always invoked with its argument `v` being an object like `{value: ..., props: ...}`.

Related to #64 .