### PR TITLE
Fix “formatter shortcut” logic in cell function.

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -70,7 +70,7 @@ module.exports = React.createClass({
 
                                 var val = fn(v.value, data, i, property);
 
-                                if(val && isUndefined(val.value)) {
+                                if(!isPlainObject(val) || isUndefined(val.value)) {
                                     // formatter shortcut
                                     val = {value: val};
                                 }

--- a/tests/table_test.js
+++ b/tests/table_test.js
@@ -101,7 +101,7 @@ describe('Table', function() {
             {
                 basic: 'basic',
                 identity: 'ident',
-                math: 123,
+                math: 23, // deliberately chosen to make cell function return 0, a falsy value
                 complex: 'somestr',
                 jsx: {id: 'some_id_123', name: 'helloworld'}
             },
@@ -114,7 +114,7 @@ describe('Table', function() {
         expect(tds.length).to.equal(columns.length);
         expect(tds[0].innerHTML).to.equal('basic');
         expect(tds[1].innerHTML).to.equal('ident');
-        expect(tds[2].innerHTML).to.equal('100');
+        expect(tds[2].innerHTML).to.equal('0');
 
         expect(tds[3].className).to.equal('complex');
         expect(tds[3].innerHTML).to.equal('somestr');


### PR DESCRIPTION
I came across a bug: given the following setup, the table cells would not display correct value.

```js
// data:
[{someColumn: 42}]

// columns:
[{
  property: 'someColumn',
  cell: v => v-42
}]

// Expected: A cell that shows "0"
// Actual: A cell that shows "42"
```

The cause lies in L73 of [src/table.js](https://github.com/bebraw/reactabular/blob/1651375213d8fc654b5049740c91e934c0dc4bad/src/table.js#L73). If `val` is falsy (like `0` in this case), it won't get wrapped as `{value: val}`, and `merge()` in [L78](https://github.com/bebraw/reactabular/blob/1651375213d8fc654b5049740c91e934c0dc4bad/src/table.js#L78) would ignore all non-object arguments when merging.

L73 should be testing if `val` needs wrapping. Thus I've fixed this by checking if `val` is a plain object instead. Hope it makes sense :)
