### PR TITLE
Fix a bug that cell functions may be skipped when two columns shares the same property

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -75,7 +75,7 @@ module.exports = React.createClass({
                                     val = {value: val};
                                 }
 
-                                return merge(v, val);
+                                return merge({}, v, val);
                             }, {value: value, props: {}});
 
                             content = content || {};

--- a/tests/table_test.js
+++ b/tests/table_test.js
@@ -152,6 +152,33 @@ describe('Table', function() {
         expect(tds[0]).to.have.property('innerHTML', 'fooContent0')
     })
 
+    it('should call cell functions for every column, even when column property conflicts', function(){
+        var columns = [
+            {
+                property: 'nestedData',
+                header: '',
+                cell: [v => <span>{v.key1}</span>]
+            },
+            {
+                property: 'nestedData',
+                header: '',
+                cell: [v => <span>{v.key2}</span>]
+            },
+        ];
+
+        var data = [
+            {nestedData: {key1: 'foo', key2: 'bar'}}
+        ];
+
+        var table = TestUtils.renderIntoDocument(
+            <Table columns={columns} data={data} />
+        );
+
+        var tds = TestUtils.scryRenderedDOMComponentsWithTag(table, 'td');
+        expect(tds[0]).to.have.deep.property('childNodes[0].innerHTML', 'foo');
+        expect(tds[1]).to.have.deep.property('childNodes[0].innerHTML', 'bar');
+    });
+
     it('should render correctly with no properties', function() {
         var renderedTable = TestUtils.renderIntoDocument(
             <Table/>


### PR DESCRIPTION
When data contains nested objects, it is useful to display two columns with the same `property` settings, and provide a cell function that reads from the nested object (see [the test](https://github.com/bebraw/reactabular/commit/91d102d9c08760820c7e5dd4f6574b3895c9014d) for example)

However, currently `<Table>` 's `render()` is flawed. The bug may cause a column's calculation result leaked to another column, which leads to the columns that share the same `property` settings renders incorrectly.

This pull request addresses the data leakage among columns and thus fixes the bug.