### PR TITLE
don't attempt to merge table cell values

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -75,7 +75,10 @@ module.exports = React.createClass({
                                     val = {value: val};
                                 }
 
-                                return merge({}, v, val);
+                                return {
+                                    value: isUndefined(val.value) ? v.value : val.value,
+                                    props: merge({}, v.props, val.props)
+                                };
                             }, {value: value, props: {}});
 
                             content = content || {};


### PR DESCRIPTION
while we want to merge the props it doesn't make sense to merge values, particularly when they are React elements. merging values that are React elements will generally lead to a browser hang / crash in non-trivial examples. this is easily observed by running the demo locally on v.0.11.1.
