### PR TITLE
Import specific lodash funcs instead of everything

### DIFF
--- a/docs/sorting_table.md
+++ b/docs/sorting_table.md
@@ -40,7 +40,7 @@ columnNames: {
 In addition we need to provide `columnNames` to our `Table` like this:
 
 ```jsx
-import {sortByOrder} from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 render() {
     var columnNames = this.state.columnNames;
@@ -52,7 +52,7 @@ render() {
     }
 
     // sorting data here
-    data = sortColumn.sort(data, this.state.sortingColumn, sortByOrder);
+    data = sortColumn.sort(data, this.state.sortingColumn, orderBy);
 
     var paginated = Paginator.paginate(data, pagination);
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "webpack-merge": "^0.8.3"
   },
   "peerDependencies": {
-    "lodash": ">= 3.5.0 < 5.0.0",
+    "lodash": ">= 4.0.0 < 5.0.0",
     "react": ">= 0.11.2 < 1.0.0"
   }
 }

--- a/src/column_names.js
+++ b/src/column_names.js
@@ -1,5 +1,5 @@
 'use strict';
-var reduce = require('lodash').reduce;
+var reduce = require('lodash/reduce');
 var React = require('react');
 
 module.exports = React.createClass({

--- a/src/search.js
+++ b/src/search.js
@@ -1,6 +1,6 @@
 'use strict';
-var isNumber = require('lodash').isNumber;
-var isString = require('lodash').isString;
+var isNumber = require('lodash/isNumber');
+var isString = require('lodash/isString');
 var React = require('react');
 
 var formatters = require('./formatters');

--- a/src/sort_column.js
+++ b/src/sort_column.js
@@ -17,8 +17,8 @@ module.exports = (columns, column, done) => {
     });
 };
 
-// sorter === lodash sortByOrder
-// https://lodash.com/docs#sortByOrder
+// sorter === lodash orderBy
+// https://lodash.com/docs#orderBy
 module.exports.sort = (data, column, sorter) => {
     if (!column) {
         return data;

--- a/src/sort_columns.js
+++ b/src/sort_columns.js
@@ -35,8 +35,8 @@ module.exports = (columns, sortColumns, column, done) => {
     });
 };
 
-// sorter === lodash sortByOrder
-// https://lodash.com/docs#sortByOrder
+// sorter === lodash orderBy
+// https://lodash.com/docs#orderBy
 module.exports.sort = (data, sortColumns, sorter) => {
     if (!sortColumns) {
         return data;

--- a/src/table.js
+++ b/src/table.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var _ = require('lodash');
-
-var merge = _.merge;
-var reduce = _.reduce;
-var isFunction = _.isFunction;
-var isPlainObject = _.isPlainObject;
-var isUndefined = _.isUndefined;
+var merge = require('lodash/merge');
+var reduce = require('lodash/reduce');
+var isFunction = require('lodash/isFunction');
+var isPlainObject = require('lodash/isPlainObject');
+var isUndefined = require('lodash/isUndefined');
 
 var React = require('react');
 var update = require('react/lib/update');


### PR DESCRIPTION
Explicitly importing subfunctions of lodash in Reactabular dramatically reduces the final bundle size of one of my projects. This is my first, bumbling foray into the React / Webpack stack, so I might be doing other ridiculous things, but this seemed like a good place to start.

Also, lodash 4.0.0 [renamed sortByOrder to orderBy](https://github.com/lodash/lodash/wiki/Changelog#v400), so this fixes that up.