### PR TITLE
Example of filtering data using different filters for each column

### DIFF
--- a/demos/App.jsx
+++ b/demos/App.jsx
@@ -4,6 +4,7 @@ var React = require('react');
 var Fork = require('react-ghfork');
 
 var FullTable = require('./full_table.jsx');
+var FullTableMultipleFilters = require('./full_table_multiple_filters.jsx');
 var EditorsTable = require('./editors_table.jsx');
 var NestedTable = require('./nested_table.jsx');
 
@@ -34,6 +35,17 @@ module.exports = React.createClass({
                         </div>
 
                         <FullTable />
+                    </section>
+                    <section className="multiple-filters">
+                      <div className='description'>
+                          <h2>Multiple filters</h2>
+
+                          <p>The table below is identical to the example above with the exception that there is a filter for each column of data.</p>
+
+                          <p>This provides the flexibility to search across multiple columns using different filters.</p>
+                      </div>
+
+                      <FullTableMultipleFilters />
                     </section>
                     <section className='editors'>
                         <div className='description'>

--- a/demos/column_filters.jsx
+++ b/demos/column_filters.jsx
@@ -4,29 +4,57 @@ var _ = require('lodash');
 
 var React = require('react');
 
-module.exports = React.createClass({
-    displayName: 'ColumnFilters',
+// This is an example of a custom header component that applies a filter to
+// each column
+class ColumnFilters extends React.Component {
+    constructor(props) {
+        super(props);
+        this.onQueryChange = this.onQueryChange.bind(this);
+        this.state = {
+            query: {}
+        };
+    }
 
-    propTypes: {
-        columns: React.PropTypes.array
-    },
+    /**
+     * Handles an input change on any of the filters.
+     */
+    onQueryChange(event) {
+        const { onChange } = this.props;
+        const { query } = this.state;
 
-    // this is just an example of a possible custom header component...
-    // inputs does nothing right now (but we can implement filtering or insertion here)
+        query[event.target.name] = event.target.value;
+
+        this.setState({ query }, () => {
+            onChange(this.state.query);
+        });
+    }
+
     render() {
-        const columns = this.props.columns;
+        const { columns } = this.props;
 
         return(
             <tr>
                 {columns.map((column, i) => {
                     return (
                         <td key={i + '-custom-header'}>
-                            {column.property ? <input className="header-input" placeholder={'Insert '+column.property} /> : ''}
+                            {column.property ?
+                              <input
+                                onChange={this.onQueryChange}
+                                className="header-input"
+                                name={column.property}
+                                placeholder={'Filter by '+column.property}
+                              />
+                            : ''}
                         </td>
                     );
                 })}
             </tr>
         );
     }
+}
+ColumnFilters.propTypes = {
+    columns: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    onChange: React.PropTypes.func.isRequired,
+};
 
-});
+module.exports = ColumnFilters;

--- a/demos/column_filters.jsx
+++ b/demos/column_filters.jsx
@@ -36,13 +36,13 @@ class ColumnFilters extends React.Component {
             <tr>
                 {columns.map((column, i) => {
                     return (
-                        <td key={i + '-custom-header'}>
-                            {column.property ?
+                        <td key={i + '-column-filter'} className='column-filter'>
+                            {column.property && !column.noFilter ?
                               <input
                                 onChange={this.onQueryChange}
-                                className="header-input"
+                                className='column-filter-input'
                                 name={column.property}
-                                placeholder={'Filter by '+column.property}
+                                placeholder={column.filterPlaceholder || ''}
                               />
                             : ''}
                         </td>

--- a/demos/full_table.jsx
+++ b/demos/full_table.jsx
@@ -72,7 +72,8 @@ module.exports = React.createClass({
         };
 
         var highlighter = (column) => highlight((value) => {
-            return Search.matches(column, value, this.state.search.query);
+            var { filter } = this.state.search;
+            return Search.matches(column, value, filter[Object.keys(filter).pop()]);
         });
 
         return {
@@ -80,8 +81,7 @@ module.exports = React.createClass({
             data: data,
             formatters: formatters,
             search: {
-                column: '',
-                query: ''
+                filter: {}
             },
             header: {
                 onClick: (column) => {
@@ -241,10 +241,10 @@ module.exports = React.createClass({
         };
     },
 
-    onSearch(search) {
+    onSearch(filter) {
         this.setState({
             editedCell: null, // reset edits
-            search: search
+            search: { filter }
         });
     },
 
@@ -266,14 +266,14 @@ module.exports = React.createClass({
 
         var data = this.state.data;
 
-        if (this.state.search.query) {
+        if (this.state.search.filter) {
             data = Search.search(
                 data,
                 columns,
-                this.state.search.column,
-                this.state.search.query
+                this.state.search.filter
             );
         }
+
 
         data = sortColumn.sort(data, this.state.sortingColumn, orderBy);
 

--- a/demos/full_table_multiple_filters.jsx
+++ b/demos/full_table_multiple_filters.jsx
@@ -20,6 +20,7 @@ var editors = require('../src/editors');
 var sortColumn = require('../src/sort_column');
 var cells = require('../src/cells');
 
+var ColumnFilters = require('./column_filters.jsx');
 var FieldWrapper = require('./field_wrapper.jsx');
 var SectionWrapper = require('./section_wrapper.jsx');
 var countries = require('./countries');
@@ -72,7 +73,7 @@ module.exports = React.createClass({
         };
 
         var highlighter = (column) => highlight((value) => {
-            return Search.matches(column, value, this.state.search.query);
+            return Search.matches(column, value, this.state.search.query[column]);
         });
 
         return {
@@ -80,8 +81,7 @@ module.exports = React.createClass({
             data: data,
             formatters: formatters,
             search: {
-                column: '',
-                query: ''
+                query: '',
             },
             header: {
                 onClick: (column) => {
@@ -241,10 +241,12 @@ module.exports = React.createClass({
         };
     },
 
-    onSearch(search) {
+    onSearch(query) {
         this.setState({
             editedCell: null, // reset edits
-            search: search
+            search: {
+                query
+            }
         });
     },
 
@@ -255,6 +257,7 @@ module.exports = React.createClass({
         return (
             <thead>
                 <ColumnNames config={headerConfig} columns={columns} />
+                <ColumnFilters columns={columns} onChange={this.onSearch} />
             </thead>
         );
     },
@@ -267,12 +270,12 @@ module.exports = React.createClass({
         var data = this.state.data;
 
         if (this.state.search.query) {
-            data = Search.search(
+            data = Search.searchMultiple(
                 data,
                 columns,
-                this.state.search.column,
                 this.state.search.query
             );
+            console.log(data);
         }
 
         data = sortColumn.sort(data, this.state.sortingColumn, orderBy);
@@ -287,9 +290,6 @@ module.exports = React.createClass({
                 <div className='controls'>
                     <div className='per-page-container'>
                         Per page <input type='text' defaultValue={pagination.perPage} onChange={this.onPerPage}></input>
-                    </div>
-                    <div className='search-container'>
-                        Search <Search columns={columns} data={this.state.data} onChange={this.onSearch} />
                     </div>
                 </div>
                 <Table

--- a/demos/full_table_multiple_filters.jsx
+++ b/demos/full_table_multiple_filters.jsx
@@ -73,7 +73,7 @@ module.exports = React.createClass({
         };
 
         var highlighter = (column) => highlight((value) => {
-            return Search.matches(column, value, this.state.search.query[column]);
+            return Search.matches(column, value, this.state.search.filter[column]);
         });
 
         return {
@@ -81,7 +81,7 @@ module.exports = React.createClass({
             data: data,
             formatters: formatters,
             search: {
-                query: '',
+                filter: {},
             },
             header: {
                 onClick: (column) => {
@@ -146,6 +146,8 @@ module.exports = React.createClass({
                         }),
                         (active) => active && <span>&#10003;</span>
                     ],
+                    filterPlaceholder: 'lol',
+                    noFilter: true
                 },
                 {
                     cell: function(value, celldata, rowIndex) {
@@ -241,12 +243,10 @@ module.exports = React.createClass({
         };
     },
 
-    onSearch(query) {
+    onSearch(filter) {
         this.setState({
             editedCell: null, // reset edits
-            search: {
-                query
-            }
+            search: { filter }
         });
     },
 
@@ -269,11 +269,11 @@ module.exports = React.createClass({
 
         var data = this.state.data;
 
-        if (this.state.search.query) {
-            data = Search.searchMultiple(
+        if (this.state.search.filter) {
+            data = Search.search(
                 data,
                 columns,
-                this.state.search.query
+                this.state.search.filter
             );
         }
 

--- a/demos/full_table_multiple_filters.jsx
+++ b/demos/full_table_multiple_filters.jsx
@@ -275,7 +275,6 @@ module.exports = React.createClass({
                 columns,
                 this.state.search.query
             );
-            console.log(data);
         }
 
         data = sortColumn.sort(data, this.state.sortingColumn, orderBy);

--- a/demos/main.css
+++ b/demos/main.css
@@ -129,7 +129,8 @@ table {
     float: right;
 }
 
-.header-input {
+.header-input,
+.column-filter-input {
     float: left;
     width: 100%;
 }

--- a/docs/searching_table.md
+++ b/docs/searching_table.md
@@ -14,16 +14,16 @@ This component lives outside your table and returns results that match the query
 
 #### Usage
 ```javascript
-    ...
-    return (
-        <div>
-            <div className='search-container'>
-                Search <Search columns={columns} data={this.state.data} onChange={this.onSearch} />
-            </div>
-            <Table columns={columns} data={this.state.search.data} rowKey={'id'} />
-            ...
+...
+return (
+    <div>
+        <div className='search-container'>
+            Search <Search columns={columns} data={this.state.data} onChange={this.onSearch} />
         </div>
-    );
+        <Table columns={columns} data={this.state.search.data} rowKey={'id'} />
+        ...
+    </div>
+);
 ```
 
 
@@ -36,26 +36,26 @@ This component is generally positioned in the header of the table and allows use
 
 #### Usage
 ```javascript
-    columnFilters() {
-        var headerConfig = this.state.header;
-        var columns = this.state.columns;
-        return (
-            <thead>
-                <ColumnNames config={headerConfig} columns={columns} />
-                <ColumnFilters columns={columns} onChange={this.onSearch} />
-            </thead>
-        );
-    },
+columnFilters() {
+    var headerConfig = this.state.header;
+    var columns = this.state.columns;
+    return (
+        <thead>
+            <ColumnNames config={headerConfig} columns={columns} />
+            <ColumnFilters columns={columns} onChange={this.onSearch} />
+        </thead>
+    );
+},
+...
+render() {
     ...
-    render() {
-        ...
-        return (
-            <div>
-                <Table columns={columns} data={this.state.search.data} columnNames={this.columnFilters} rowKey={'id'} />
-                ...
-            </div>
-        );
-    }
+    return (
+        <div>
+            <Table columns={columns} data={this.state.search.data} columnNames={this.columnFilters} rowKey={'id'} />
+            ...
+        </div>
+    );
+}
 
 ```
 
@@ -83,7 +83,6 @@ var columns = [
 
 Here is an example of handling a search callback:
 ```javascript
-The search filter can 
 getInitialState() {
     return {
         search: {

--- a/docs/searching_table.md
+++ b/docs/searching_table.md
@@ -1,77 +1,122 @@
 # Searching a Table
 
-`Reactabular` comes with a search helper that can be hooked up. See below:
+`Reactabular` comes with a two pre-built search helpers that can be hooked up to your table.
+
+## Components
+
+### Option 1: Searching all (or one) field dropdown + input
 
 ```javascript
 var Search = require('reactabular').Search;
-
-...
-
-
-var columns = [
-    ...
-    {
-        property: 'followers',
-        header: 'Followers',
-        // accuracy per hundred is enough for demoing
-        cell: (followers) => followers - (followers % 100),
-        // search targets values by default. we can customize
-        // it by providing a custom data formatter to it to get
-        // matches you might expect
-        search: (followers) => followers - (followers % 100),
-    },
-    ...
-];
-
-...
-
-getInitialState() {
-    return {
-        ...
-        search: {
-            column: '',
-            query: ''
-        },
-        ...
-    };
-}
-
-...
-
-onSearch(search) {
-    this.setState({
-        search: search
-    });
-},
 ```
 
-Then at your `render` you could do:
+This component lives outside your table and returns results that match the query in any of the columns, or if set, in a single column.
 
+#### Usage
 ```javascript
-render() {
-    var data = this.state.data;
-
-    if (this.state.search.query) {
-        // apply search to data
-        // alternatively you could hit backend `onChange`
-        // or push this part elsewhere depending on your needs
-        data = Search.search(
-            data,
-            columns,
-            this.state.search.column,
-            this.state.search.query
-        );
-    }
-
+    ...
     return (
         <div>
             <div className='search-container'>
                 Search <Search columns={columns} data={this.state.data} onChange={this.onSearch} />
             </div>
             <Table columns={columns} data={this.state.search.data} rowKey={'id'} />
-        ...
+            ...
         </div>
     );
+```
+
+
+### Option 2: A search field for each column
+```javascript
+var Search = require('reactabular').SearchMultiple;
+```
+
+This component is generally positioned in the header of the table and allows users to filter by individual columns.
+
+#### Usage
+```javascript
+    columnFilters() {
+        var headerConfig = this.state.header;
+        var columns = this.state.columns;
+        return (
+            <thead>
+                <ColumnNames config={headerConfig} columns={columns} />
+                <ColumnFilters columns={columns} onChange={this.onSearch} />
+            </thead>
+        );
+    },
+    ...
+    render() {
+        ...
+        return (
+            <div>
+                <Table columns={columns} data={this.state.search.data} columnNames={this.columnFilters} rowKey={'id'} />
+                ...
+            </div>
+        );
+    }
+
+```
+
+
+## Handling search results
+
+A column becomes searchable when it has a unique 'property' property for each column.
+In the following example, the __Followers__ and __Tweets__ columns are searchable but __Actions__ is not.
+```javascript
+var columns = [
+    {
+        property: 'followers',
+        header: 'Followers',
+    },
+    {
+        property: 'tweets',
+        header: 'Tweets',
+    },
+    {
+        // This column is NOT searched because it has no 'property' property
+        header: 'Actions',
+    }
+];
+```
+
+Here is an example of handling a search callback:
+```javascript
+The search filter can 
+getInitialState() {
+    return {
+        search: {
+            filter: {}
+        },
+    };
+}
+
+onSearch(filter) {
+    this.setState({
+        search: { filter }
+    });
+},
+```
+
+In your `render` method, you could do something like the following:
+
+```javascript
+render() {
+    var data = this.state.data;
+
+    if (this.state.search.filter) {
+        // Apply the filter(s) to the data
+        // Alternatively you could hit a backend `onChange` method,
+        // or push this part elsewhere depending on your needs
+        data = Search.search(
+            data,
+            columns,
+            this.state.search.filter,
+        );
+    }
+
+    return (...);
 }
 ```
 
@@ -96,7 +141,13 @@ We can highlight individual search results by using a premade `highlight` helper
 ```javascript
 var highlight = require('reactabular/formatters/highlight');
 var highlighter = (column) => highlight((value) => {
-    return Search.matches(column, value, this.state.search.query);
+    var { filter } = this.state.search;
+    
+    // To highlight all matches based on a single filter (e.g. when using the search dropdown)
+    return Search.matches(column, value, filter[Object.keys(filter).pop()]);
+    
+    // To highlight matches only in the searched column
+    return Search.matches(column, value, this.state.search.filter[column]);
 });
 
 ...

--- a/src/search.js
+++ b/src/search.js
@@ -76,8 +76,7 @@ module.exports = React.createClass({
         });
 
         this.props.onChange({
-            column: column,
-            query: query,
+            [column]: query
         });
     },
 
@@ -87,22 +86,19 @@ module.exports = React.createClass({
         this.setState({
             query: query
         });
-
         this.props.onChange({
-            column: column,
-            query: query,
+            [column]: query
         });
     },
 
     componentDidMount() {
         this.props.onChange({
-            column: this.state.column,
-            query: this.state.query
+            [this.state.column]: this.state.query
         });
     },
 });
 
-var search = (data, columns, column, query, options) => {
+var searchColumn = (data, columns, column, query, options) => {
     if(!query) {
         return data;
     }
@@ -144,9 +140,9 @@ var search = (data, columns, column, query, options) => {
         return predicate.evaluate(options.transform(formattedValue));
     }
 };
-module.exports.search = search;
+module.exports.searchColumn = searchColumn;
 
-module.exports.searchMultiple = (data, columns, query, options) => {
+module.exports.search = (data, columns, query, options) => {
     if (!query) {
         return data;
     }
@@ -155,7 +151,7 @@ module.exports.searchMultiple = (data, columns, query, options) => {
 
     data = searchColumns.reduce(
         (filteredData, column) => {
-            return search(filteredData, columns, column, query[column], options);
+            return searchColumn(filteredData, columns, column, query[column], options);
         },
         data
     );

--- a/src/search.js
+++ b/src/search.js
@@ -102,7 +102,7 @@ module.exports = React.createClass({
     },
 });
 
-module.exports.search = (data, columns, column, query, options) => {
+var search = (data, columns, column, query, options) => {
     if(!query) {
         return data;
     }
@@ -143,6 +143,24 @@ module.exports.search = (data, columns, column, query, options) => {
 
         return predicate.evaluate(options.transform(formattedValue));
     }
+};
+module.exports.search = search;
+
+module.exports.searchMultiple = (data, columns, query, options) => {
+    if (!query) {
+        return data;
+    }
+
+    var searchColumns = Object.keys(query);
+
+    data = searchColumns.reduce(
+        (filteredData, column) => {
+            return search(filteredData, columns, column, query[column], options);
+        },
+        data
+    );
+
+    return data;
 };
 
 module.exports.matches = (column, value, query, options) => {


### PR DESCRIPTION
This adds an example of how to add a filter for each individual column of data, as was requested in #114. Each filter is then applied to the data in succession so the data for each search call is the result of the previous call.

- Wired up the ColumnFilters demo component
- Moved the ColumnFilters component from the FullTable demo component to a new FullTableMultipleFilters component which demonstrates the functionality of this PR
- Added a method _searchMultiple_ that searches across columns, successively filtering the table data