### PR TITLE
clarify sort usage

### DIFF
--- a/docs/sorting_table.md
+++ b/docs/sorting_table.md
@@ -1,75 +1,91 @@
 # Sorting a Table
 
-Reactabular comes with a little helper to make sorting easier. It is possible to replace the provided sorter with something more advanced. Here's the basic idea:
+Reactabular comes with helpers to make sorting easier right out of the box.
 
-```javascript
-var sortColumn = require('reactabular').sortColumn;
+The general workflow is as follows:
 
-...
+1. import the sort helper. the sort helper does two things:
+  - updates your component's state, which dictates how the table is to be sorted
+  - exposes a `.sort` function to actually sort the data
+1. set up click handlers to update which column(s) we're sorting against
+1. sort the data, pre-render
+1. feed in the sorted data to your `reactabular` table
 
-// state
-columnNames: {
-    onClick: (column) => {
-        sortColumn(
-            this.state.columns,
-            column,
-            this.setState.bind(this)
-        );
-    },
+#### import the sort utility
+
+```js
+var sortUtility = require('reactabular').sortColumn;
+```
+
+or, if you want to support sorting against multiple columns:
+
+```js
+var sortUtility = require('reactabular').sortColumns;
+```
+
+#### setup click handlers
+```js
+// place in getInitialState, or, if using es6 classes, `this.setState = ...`
+{
+  someOtherInitialState: ...,
+  // for supporting sort against a single column at a time
+  columnNames: {
+      onClick: (column) => {
+          sortUtility(
+              this.state.columns,
+              column,
+              this.setState.bind(this)
+          );
+      },
+  },
+  // or...
+  // for supporting sort against a multiple columns
+  columnNames: {
+      onClick: (column) => {
+          sortUtility(
+              this.state.columns,
+              this.state.sortedColumns,
+              column,
+              this.setState.bind(this)
+          );
+      },
+  }
 }
 ```
 
-A more sophisticated (multi-column) sort example (each column can be independently cycled through ascending, descending, and no sort, and sorts are applied in the order they were invoked via the following onClick handler):
+#### sort & render
 
-```javascript
-var sortColumns = require('reactabular').sortColumns;
-
-...
-
-// state
-columnNames: {
-    onClick: (column) => {
-        sortColumns(
-            this.state.columns,
-            this.state.sortedColumns,
-            column,
-            this.setState.bind(this)
-        );
-    },
-}
-```
-
-In addition we need to provide `columnNames` to our `Table` like this:
-
-```jsx
+```js
 import orderBy from 'lodash/orderBy';
 
 render() {
     var columnNames = this.state.columnNames;
     var data = this.state.data;
-    var pagination = this.state.pagination;
+    var sortingColumn = this.state.sortingColumn;
+    // ^^ this.state.sortingColumn OR this.state.sortingColumns,
+    // depending on which sortUtility you imported
 
-    if (this.state.search.query) {
-        ... // search logic
-    }
+    // sort data!
+    data = sortUtility.sort(data, sortingColumn, orderBy);
 
-    // sorting data here
-    data = sortColumn.sort(data, this.state.sortingColumn, orderBy);
-
-    var paginated = Paginator.paginate(data, pagination);
-
+  // @NOTE, `columnNames` is required for sorting.
+  // the imported sortUtility manages this attr for us
     return (
-        <div>
-            ...
-            <Table columns={columns} data={paginated.data} columnNames={columnNames} />
-            ...,
-        </div>
+        <Table
+            columns={columns}
+            data={paginated.data}
+            columnNames={columnNames}
+        />
     );
 }
 ```
 
-After that it should be possible to sort table content by hitting various column names at header. `sortColumn` sets either `sort-asc` or `sort-desc` class for currently active header column. This allows some degree of styling.
+Now, you should be able to sort table content by clicking header cells.
 
-You can get something basic looking by utilizing `./style.css`. In Webpack you can import it to your project using `require('reactabular/style.css')` provided you have appropriate loaders set up.
+The imported `sortUtility` sets either the `sort-asc` or `sort-desc` class for currently active header column. This allows some degree of styling.
 
-> `header` key-value pairs will be applied as attributes to `th`'s. If you have an event handler (ie. something starting with `on`), the first parameter provided will be the column in question. The second one will be React event.
+You can get something basic styles (e.g. UP/DOWN arrows) by importing `./style.css`. In Webpack you can import it to your project using `require('reactabular/style.css')` provided you have appropriate loaders set up.
+
+##### sort events
+
+`header` key-value pairs will be applied as attributes to `th`'s. If you have an event handler (ie. something starting with `.on`), the first parameter provided will be the column in question. The second one will be React event.

--- a/docs/sorting_table.md
+++ b/docs/sorting_table.md
@@ -39,7 +39,7 @@ var sortUtility = require('reactabular').sortColumns;
       },
   },
   // or...
-  // for supporting sort against a multiple columns
+  // for supporting sort against multiple columns
   columnNames: {
       onClick: (column) => {
           sortUtility(
@@ -55,7 +55,7 @@ var sortUtility = require('reactabular').sortColumns;
 
 #### sort & render
 
-```js
+```jsx
 import orderBy from 'lodash/orderBy';
 
 render() {


### PR DESCRIPTION
#### problem statement

- sort documentation is unclear.
- sort documentation has cruft (e.g. `pagination/query/etc` code) that distracts from the actual sorting content
- sort documentation, whilst accurate,  is hard to disambiguate between the many usages of the term `sort` (e.g. the imported sort function, the sort-related state, and the sorted content)

#### solution

- provide a discrete outline for how to sort your table data
- vary terminology to prevent possible ambiguation
- remove cruft

#### discussion

thanks for the great lib!  respectfully, it took me too long to interpret exactly what was going on here.  i patched the existing docs such that someone can open, read from top to bottom, and have absolute clarity on how to get their data sorted. hopefully the change will be welcomed!  it may be able to view the file raw/rendered vs looking at the diff