### PR TITLE
Replace this.getDOMNode() with findDOMNode

### DIFF
--- a/src/editors/input.js
+++ b/src/editors/input.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var React = require('react');
-
+var findDOMNode = require('react-dom').findDOMNode;
 
 module.exports = (attrs) => {
     attrs = attrs || {};
@@ -55,7 +55,7 @@ module.exports = (attrs) => {
         },
 
         done() {
-            this.props.onValue(this.getDOMNode().value);
+            this.props.onValue(findDOMNode(this).value);
         },
     });
 };


### PR DESCRIPTION
Using `this.getDOMNode` is now an error, instead of a deprecation warning.
A quick search replace reveals that only `editors/input.js` uses it. This PR replaces it with `ReactDOM.findDOMNode`.