### PR TITLE
Resolve bug in lib/post_install.js for node 0.10.x

### DIFF
--- a/lib/post_install.js
+++ b/lib/post_install.js
@@ -1,21 +1,32 @@
 #!/usr/bin/env node
 // adapted based on rackt/history (MIT)
-var execSync = require('child_process').execSync;
+var spawn = require('child_process').spawn;
 var stat = require('fs').stat;
-
-if (!execSync) {
-    execSync = require('sync-exec');
-}
-
-function exec(command) {
-    execSync(command, {
-        stdio: [0, 1, 2]
-    });
-}
 
 stat('dist-modules', function(error, stat) {
     if (error || !stat.isDirectory()) {
-        exec('npm i babel-cli babel-preset-es2015 babel-preset-react babel-plugin-syntax-object-rest-spread babel-plugin-transform-object-rest-spread');
-        exec('npm run dist-modules');
+        var devInstall = spawn(
+            'npm',
+            [
+                'i',
+                'babel-cli',
+                'babel-preset-es2015',
+                'babel-preset-react',
+                'babel-plugin-syntax-object-rest-spread',
+                'babel-plugin-transform-object-rest-spread'
+            ],
+            {
+                stdio: [0, 1, 2]
+            }
+        );
+
+        devInstall.on('close', function(exitCode) {
+            var transpile = spawn('npm', ['run', 'dist-modules'], { stdio: [0, 1, 2] });
+
+            transpile.on('close', function() {
+                spawn('npm', ['prune', '--production'], { stdio: [0, 1, 2] });
+            });
+        });
     }
 });
+

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "schema2object": "^0.4.0",
     "segmentize": "^0.4.1",
     "style-loader": "^0.13.1",
-    "sync-exec": "^0.6.2",
     "title-case": "^1.1.2",
     "url-loader": "^0.5.7",
     "uuid": "^2.0.2",


### PR DESCRIPTION
execSync is replaced with spawn, and the dependency sync-exec is dropped.
Also, `npm prune --production` is run after the transpilation, to remove
unecessary devDependencies.