### PR TITLE
Use full resolver incantation

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -46,7 +46,7 @@ const _columnMatches = ({ // eslint-disable-line no-underscore-dangle
   const property = column.cell.property;
   const value = get(row, property);
   const formatter = column.cell.resolve || (a => a);
-  let formattedValue = formatter(value);
+  let formattedValue = formatter(value, {cellData: row, property});
 
   if (typeof formattedValue === 'undefined') {
     formattedValue = '';


### PR DESCRIPTION
Just a small fix – the search wasn't working for me when I had resolvers that used `cellData`.